### PR TITLE
Rewrite Dockerfile to use build step for wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ RUN apt-get update && \
 		apt-get install -y --no-install-recommends \
 			libffi-dev=* \
 			build-essential=* && \
-		rm -rf /var/lib/apt/lists/*;
-
-RUN pip install --no-cache-dir --upgrade "ansible-lint[community,yamllint]"==5.0.8
+		rm -rf /var/lib/apt/lists/* && \\
+		pip install --no-cache-dir --upgrade "ansible-lint[community,yamllint]"==5.0.8
 
 FROM python:3-slim
 LABEL maintainer="Christoph Kepler <christoph.kepler@tyclipso.net>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
 		apt-get install -y --no-install-recommends \
 			libffi-dev=* \
 			build-essential=* && \
-		rm -rf /var/lib/apt/lists/* && \\
+		rm -rf /var/lib/apt/lists/* && \
 		pip install --no-cache-dir --upgrade "ansible-lint[community,yamllint]"==5.0.8
 
 FROM python:3-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
+FROM python:3-slim AS wheel
+
+RUN apt-get update && \
+		apt-get install -y --no-install-recommends \
+			libffi-dev=* \
+			build-essential=* && \
+		rm -rf /var/lib/apt/lists/*;
+
+RUN pip install --no-cache-dir --upgrade "ansible-lint[community,yamllint]"==5.0.8
+
 FROM python:3-slim
 LABEL maintainer="Christoph Kepler <christoph.kepler@tyclipso.net>"
 
-RUN pip install --no-cache-dir --upgrade "ansible-lint[community,yamllint]"==5.0.8
+COPY --from=wheel /usr/local/lib /usr/local/lib
+COPY --from=wheel /usr/local/bin /usr/local/bin


### PR DESCRIPTION
Apparently libffi is not enough anymore and wheel needs to be compiled for cffi.
This lead to problems since gcc is not available and failed the CI run.
Additionally libffi-dev and build-essential is needed to successful compile wheels.