### PR TITLE
Return to python:3-slim instead of pinning 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3-slim
 LABEL maintainer="Christoph Kepler <christoph.kepler@tyclipso.net>"
 
 RUN pip install --no-cache-dir --upgrade "ansible-lint[community,yamllint]"==5.2.0


### PR DESCRIPTION
Since cffi, cryptography and others now have wheels for 3.10 we can use
latest python 3 again without having to install all build-essentials.

Superseeds and closes #3