### PR TITLE
Labels and edge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: "${{ github.repository }}"
 
 jobs:
 
@@ -79,7 +78,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
             type=ref,event=tag
 
@@ -88,7 +87,7 @@ jobs:
         if: false == startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
             type=sha,prefix=
 
@@ -104,4 +103,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:bleeding,${{ steps.meta_bleeding.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:bleeding,${{ steps.meta_bleeding.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           push: true
           tags: ${{ steps.meta_tag.outputs.tags }}
+          labels: ${{ steps.meta_tag.outputs.labels }}
 
       - name: Build and push Docker image (bleeding)
         if: false == startsWith(github.ref, 'refs/tags/v')
@@ -105,3 +106,4 @@ jobs:
         with:
           push: true
           tags: ${{ steps.meta_bleeding.outputs.tags }}
+          labels: ${{ steps.meta_bleeding.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
+            type=edge
             type=sha,prefix=
 
       - name: Build and push Docker image (tag)
@@ -103,4 +104,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:bleeding,${{ steps.meta_bleeding.outputs.tags }}
+          tags: ${{ steps.meta_bleeding.outputs.tags }}


### PR DESCRIPTION
This PR adds labels generated by the metadata-action for the opencontainer spec.
It switches from bleeding tagging to in-built edge tagging from the metadata.
Additionally it removes the `IMAGE_NAME` variable since it just points to `github.repository`.